### PR TITLE
Disable quadruple precision support by default

### DIFF
--- a/src/testdrive.F90
+++ b/src/testdrive.F90
@@ -13,7 +13,7 @@
 
 !# Enable support for quadruple precision
 #ifndef WITH_QP
-#define WITH_QP 1
+#define WITH_QP 0
 #endif
 
 !# Enable support for extended double precision

--- a/test/test_check.F90
+++ b/test/test_check.F90
@@ -13,7 +13,7 @@
 
 !# Enable support for quadruple precision
 #ifndef WITH_QP
-#define WITH_QP 1
+#define WITH_QP 0
 #endif
 
 !# Enable support for extended double precision


### PR DESCRIPTION
Relevant for #7 
Relevant for https://github.com/fortran-lang/stdlib/issues/527