### PR TITLE
Bump to version 0.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ get_directory_property(is-subproject PARENT_DIRECTORY)
 project(
   "test-drive"
   LANGUAGES "Fortran"
-  VERSION "0.3.0"
+  VERSION "0.4.0"
   DESCRIPTION "The simple testing framework"
 )
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # The simple testing framework
 
 [![License](https://img.shields.io/badge/license-MIT%7CApache%202.0-blue)](LICENSE-Apache)
+[![Latest Version](https://img.shields.io/github/v/release/fortran-lang/test-drive)](https://github.com/fortran-lang/test-drive/releases/latest)
 [![CI](https://github.com/fortran-lang/test-drive/workflows/CI/badge.svg)](https://github.com/fortran-lang/test-drive/actions)
 [![codecov](https://codecov.io/gh/fortran-lang/test-drive/branch/main/graph/badge.svg)](https://codecov.io/gh/fortran-lang/test-drive)
 

--- a/fpm.toml
+++ b/fpm.toml
@@ -1,5 +1,5 @@
 name = "test-drive"
-version = "0.3.0"
+version = "0.4.0"
 license = "Apache-2.0 OR MIT"
 maintainer = ["@awvwgk"]
 author = ["Sebastian Ehlert"]

--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,7 @@
 project(
   'test-drive',
   'fortran',
-  version: '0.3.0',
+  version: '0.4.0',
   license: 'Apache-2.0 OR MIT',
   meson_version: '>=0.53',
   default_options: [

--- a/src/testdrive_version.f90
+++ b/src/testdrive_version.f90
@@ -20,10 +20,10 @@ module testdrive_version
 
 
    !> String representation of the test-drive version
-   character(len=*), parameter :: testdrive_version_string = "0.3.0"
+   character(len=*), parameter :: testdrive_version_string = "0.4.0"
 
    !> Numeric representation of the test-drive version
-   integer, parameter :: testdrive_version_compact(3) = [0, 3, 0]
+   integer, parameter :: testdrive_version_compact(3) = [0, 4, 0]
 
 
 contains


### PR DESCRIPTION
Release notes:

- namespace CMake tests to avoid clashes when used as subproject
- add optional support for quadruple and extended double precision (autodetects in meson and CMake, opt-in for fpm)