### PR TITLE
Fix fetch method causing test-drive tests to be included in CTest list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,6 @@ project(
   DESCRIPTION "The simple testing framework"
 )
 
-option(TEST_DRIVE_BUILD_TESTING "Enable tests for test-drive framework" ON)
-
 # Follow GNU conventions for installing directories
 include(GNUInstallDirs)
 
@@ -98,7 +96,7 @@ install(
 )
 
 # add the testsuite
-if (TEST_DRIVE_BUILD_TESTING)
-  enable_testing()
+include(CTest)
+if(BUILD_TESTING AND TEST_DRIVE_BUILD_TESTING)
   add_subdirectory("test")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ project(
   DESCRIPTION "The simple testing framework"
 )
 
+option(TEST_DRIVE_BUILD_TESTING "Enable tests for test-drive framework" ON)
+
 # Follow GNU conventions for installing directories
 include(GNUInstallDirs)
 
@@ -96,5 +98,7 @@ install(
 )
 
 # add the testsuite
-enable_testing()
-add_subdirectory("test")
+if (TEST_DRIVE_BUILD_TESTING)
+  enable_testing()
+  add_subdirectory("test")
+endif()

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 option(BUILD_SHARED_LIBS "Whether the libraries built should be shared" FALSE)
+option(TEST_DRIVE_BUILD_TESTING "Enable testing for this project" ON)
 
 set(
   module-dir


### PR DESCRIPTION
Good evening folks,

Thanks for all the work you are doing to reviving Fortran into a more modern language!

I'm attempting to add some unit testing to a rather old Fortran code base using CMake, and followed the steps shown in this repository for integrating `test-drive` into my project. However, I noticed rather quickly that the tests from `test-drive` were making it into my own project testing and failing:

```
$ make all test
...
25% tests passed, 3 tests failed out of 4

Total Test time (real) =   0.01 sec

The following tests FAILED:
          2 - test-drive/all-tests (Not Run)
          3 - test-drive/check (Not Run)
          4 - test-drive/select (Not Run)
```

I don't think this happens on the `cmake` and `pkgconf` methods in `Findtest-drive.cmake`, because both of those are installed paths with no mention of tests.

This pull request fixes this by defining a `TEST_DRIVE_BUILD_TESTING` option that will not be defined if `test-drive` is linked to after `FetchContent`.

