### PR TITLE
Adding output to JUnit.xml with JUnit schema files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@
 /build*/
 /_*/
 /docs*/
+/.vs
+/out/build/x64-Debug

--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,3 @@
 /build*/
 /_*/
 /docs*/
-/.vs
-/out/build/x64-Debug

--- a/src/JUnit.xml
+++ b/src/JUnit.xml
@@ -1,0 +1,321 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="JUnit.xsd">
+  <testsuite name="check" package="unknown" id="1" timestamp="2023-07-26T16:06:44" hostname="NB1211284">
+    <properties>
+    </properties>
+    <testcase name="success" classname="unknown"/>
+    <testcase name="failure" classname="unknown">
+      <system-out>
+           Non-zero exit code encountered
+      </system-out>
+    </testcase>
+    <testcase name="failure-message" classname="unknown">
+      <system-out>
+           Custom message describing the error
+      </system-out>
+    </testcase>
+    <testcase name="failure-with-more" classname="unknown">
+      <system-out>
+           Non-zero exit code encountered
+           with an additional descriptive message here
+      </system-out>
+    </testcase>
+    <testcase name="expression" classname="unknown"/>
+    <testcase name="expression-fail" classname="unknown">
+      <system-out>
+           Condition not fullfilled
+      </system-out>
+    </testcase>
+    <testcase name="expression-message" classname="unknown">
+      <system-out>
+           index("info!", "!") == 0
+      </system-out>
+    </testcase>
+    <testcase name="expression-with-more" classname="unknown">
+      <system-out>
+           Condition not fullfilled
+           index("info!", "?")
+      </system-out>
+    </testcase>
+    <testcase name="real-single-abs" classname="unknown"/>
+    <testcase name="real-single-rel" classname="unknown"/>
+    <testcase name="real-single-nan" classname="unknown">
+      <system-out>
+           Exceptional value 'not a number' found
+      </system-out>
+    </testcase>
+    <testcase name="real-single-abs-fail" classname="unknown">
+      <system-out>
+           Floating point value missmatch
+           expected 2.000000 but got 1.000000 (difference: 1.000000)
+      </system-out>
+    </testcase>
+    <testcase name="real-single-rel-fail" classname="unknown">
+      <system-out>
+           Floating point value missmatch
+           expected 1.500000 but got 1.000000 (difference: 33%)
+      </system-out>
+    </testcase>
+    <testcase name="real-single-abs-message" classname="unknown">
+      <system-out>
+           Actual value is not 1.5
+      </system-out>
+    </testcase>
+    <testcase name="real-single-nan-message" classname="unknown">
+      <system-out>
+           Actual value is not a number
+      </system-out>
+    </testcase>
+    <testcase name="real-double-abs" classname="unknown"/>
+    <testcase name="real-double-rel" classname="unknown"/>
+    <testcase name="real-double-nan" classname="unknown">
+      <system-out>
+           Exceptional value 'not a number' found
+      </system-out>
+    </testcase>
+    <testcase name="real-double-abs-fail" classname="unknown">
+      <system-out>
+           Floating point value missmatch
+           expected 2.000000000000000 but got 1.000000000000000 (difference: 1.000000000000000)
+      </system-out>
+    </testcase>
+    <testcase name="real-double-rel-fail" classname="unknown">
+      <system-out>
+           Floating point value missmatch
+           expected 1.500000000000000 but got 1.000000000000000 (difference: 33%)
+      </system-out>
+    </testcase>
+    <testcase name="real-double-abs-message" classname="unknown">
+      <system-out>
+           Actual value is not 1.5
+      </system-out>
+    </testcase>
+    <testcase name="real-double-nan-message" classname="unknown">
+      <system-out>
+           Actual value is not a number
+      </system-out>
+    </testcase>
+    <testcase name="complex-single-abs" classname="unknown"/>
+    <testcase name="complex-single-rel" classname="unknown"/>
+    <testcase name="complex-single-nan" classname="unknown">
+      <system-out>
+           Exceptional value 'not a number' found
+      </system-out>
+    </testcase>
+    <testcase name="complex-single-abs-fail" classname="unknown">
+      <system-out>
+           Floating point value missmatch
+           expected (2.000000, 1.000000) but got (1.000000, 2.000000) (difference: 1.414214)
+      </system-out>
+    </testcase>
+    <testcase name="complex-single-rel-fail" classname="unknown">
+      <system-out>
+           Floating point value missmatch
+           expected (1.500000, 1.000000) but got (1.000000, 1.500000) (difference: 39%)
+      </system-out>
+    </testcase>
+    <testcase name="complex-single-abs-message" classname="unknown">
+      <system-out>
+           Actual value is not 1.5+1.0i
+      </system-out>
+    </testcase>
+    <testcase name="complex-single-nan-message" classname="unknown">
+      <system-out>
+           Actual value is not a number
+      </system-out>
+    </testcase>
+    <testcase name="complex-double-abs" classname="unknown"/>
+    <testcase name="complex-double-rel" classname="unknown"/>
+    <testcase name="complex-double-nan" classname="unknown">
+      <system-out>
+           Exceptional value 'not a number' found
+      </system-out>
+    </testcase>
+    <testcase name="complex-double-abs-fail" classname="unknown">
+      <system-out>
+           Floating point value missmatch
+           expected (2.000000000000000, 1.000000000000000) but got (1.000000000000000, 2.000000000000000) (difference: 1.414213562373095)
+      </system-out>
+    </testcase>
+    <testcase name="complex-double-rel-fail" classname="unknown">
+      <system-out>
+           Floating point value missmatch
+           expected (1.500000000000000, 1.000000000000000) but got (1.000000000000000, 1.500000000000000) (difference: 39%)
+      </system-out>
+    </testcase>
+    <testcase name="complex-double-abs-message" classname="unknown">
+      <system-out>
+           Actual value is not 1.5+1.0i
+      </system-out>
+    </testcase>
+    <testcase name="complex-double-nan-message" classname="unknown">
+      <system-out>
+           Actual value is not a number
+      </system-out>
+    </testcase>
+    <testcase name="integer-char" classname="unknown"/>
+    <testcase name="integer-char-fail" classname="unknown">
+      <system-out>
+           Integer value missmatch
+           expected -4 but got 3
+      </system-out>
+    </testcase>
+    <testcase name="integer-char-message" classname="unknown">
+      <system-out>
+           Actual value is not seven
+      </system-out>
+    </testcase>
+    <testcase name="integer-char-with-more" classname="unknown">
+      <system-out>
+           Integer value missmatch
+           expected 3 but got 0
+           with an additional descriptive message here
+      </system-out>
+    </testcase>
+    <testcase name="integer-short" classname="unknown"/>
+    <testcase name="integer-short-fail" classname="unknown">
+      <system-out>
+           Integer value missmatch
+           expected -4 but got 3
+      </system-out>
+    </testcase>
+    <testcase name="integer-short-message" classname="unknown">
+      <system-out>
+           Actual value is not seven
+      </system-out>
+    </testcase>
+    <testcase name="integer-short-with-more" classname="unknown">
+      <system-out>
+           Integer value missmatch
+           expected 3 but got 0
+           with an additional descriptive message here
+      </system-out>
+    </testcase>
+    <testcase name="integer-default" classname="unknown"/>
+    <testcase name="integer-default-fail" classname="unknown">
+      <system-out>
+           Integer value missmatch
+           expected -4 but got 3
+      </system-out>
+    </testcase>
+    <testcase name="integer-default-message" classname="unknown">
+      <system-out>
+           Actual value is not seven
+      </system-out>
+    </testcase>
+    <testcase name="integer-default-with-more" classname="unknown">
+      <system-out>
+           Integer value missmatch
+           expected 3 but got 0
+           with an additional descriptive message here
+      </system-out>
+    </testcase>
+    <testcase name="integer-long" classname="unknown"/>
+    <testcase name="integer-long-fail" classname="unknown">
+      <system-out>
+           Integer value missmatch
+           expected -4 but got 3
+      </system-out>
+    </testcase>
+    <testcase name="integer-long-message" classname="unknown">
+      <system-out>
+           Actual value is not seven
+      </system-out>
+    </testcase>
+    <testcase name="integer-long-with-more" classname="unknown">
+      <system-out>
+           Integer value missmatch
+           expected 3 but got 0
+           with an additional descriptive message here
+      </system-out>
+    </testcase>
+    <testcase name="logical-default-true" classname="unknown"/>
+    <testcase name="logical-default-false" classname="unknown"/>
+    <testcase name="logical-default-fail" classname="unknown">
+      <system-out>
+           Logical value missmatch
+           expected F but got T
+      </system-out>
+    </testcase>
+    <testcase name="logical-default-message" classname="unknown">
+      <system-out>
+           Logical value is not true
+      </system-out>
+    </testcase>
+    <testcase name="logical-default-with-more" classname="unknown">
+      <system-out>
+           Logical value missmatch
+           expected F but got T
+           with an additional descriptive message
+      </system-out>
+    </testcase>
+    <testcase name="character" classname="unknown"/>
+    <testcase name="character-fail" classname="unknown">
+      <system-out>
+           Character value missmatch
+           expected 'negative' but got 'positive'
+      </system-out>
+    </testcase>
+    <testcase name="character-message" classname="unknown">
+      <system-out>
+           Character string should be negative
+      </system-out>
+    </testcase>
+    <testcase name="character-with-more" classname="unknown">
+      <system-out>
+           Character value missmatch
+           expected 'negative' but got 'positive'
+           with an additional descriptive message
+      </system-out>
+    </testcase>
+    <testcase name="character-with-more" classname="unknown">
+      <system-out>
+           Character value missmatch
+           expected 'negative' but got 'positive'
+           with an additional descriptive message
+      </system-out>
+    </testcase>
+    <testcase name="string-i1" classname="unknown"/>
+    <testcase name="string-i2" classname="unknown"/>
+    <testcase name="string-i4" classname="unknown"/>
+    <testcase name="string-i8" classname="unknown"/>
+  <system-out/>
+  <system-err/>
+  </testsuite>
+  <testsuite name="select" package="unknown" id="2" timestamp="2023-07-26T16:06:44" hostname="NB1211284">
+    <properties>
+    </properties>
+    <testcase name="always-pass" classname="unknown"/>
+    <testcase name="always-fail" classname="unknown">
+      <system-out>
+           Always failing test
+      </system-out>
+    </testcase>
+    <testcase name="always-pass" classname="unknown"/>
+    <testcase name="always-fail" classname="unknown">
+      <system-out>
+           Always failing test
+      </system-out>
+    </testcase>
+    <testcase name="run-good-suite" classname="unknown"/>
+    <testcase name="always-pass" classname="unknown">
+      <failure message="UNEXPECTED PASS" type="unknown"/>
+    </testcase>
+    <testcase name="always-fail" classname="unknown">
+      <failure message="FAILED" type="unknown"/>
+      <system-out>
+           Always failing test
+      </system-out>
+    </testcase>
+    <testcase name="run-bad-suite" classname="unknown"/>
+    <testcase name="always-fail" classname="unknown">
+      <system-out>
+           Always failing test
+      </system-out>
+    </testcase>
+    <testcase name="run-selected" classname="unknown"/>
+    <testcase name="select-missing" classname="unknown"/>
+  <system-out/>
+  <system-err/>
+  </testsuite>
+</testsuites>

--- a/src/JUnit.xsd
+++ b/src/JUnit.xsd
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+  <xs:annotation>
+    <xs:documentation xml:lang="en">JUnit test result schema for the Apache Ant JUnit and JUnitReport tasks
+Copyright © 2011, Windy Road Technology Pty. Limited
+The Apache Ant JUnit XML Schema is distributed under the terms of the Apache License Version 2.0 http://www.apache.org/licenses/
+Permission to waive conditions of this license may be requested from Windy Road Support (http://windyroad.org/support).</xs:documentation>
+  </xs:annotation>
+  <xs:element name="testsuite" type="testsuite"/>
+  <xs:simpleType name="ISO8601_DATETIME_PATTERN">
+    <xs:restriction base="xs:dateTime">
+      <xs:pattern value="[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:element name="testsuites">
+    <xs:annotation>
+      <xs:documentation xml:lang="en">Contains an aggregation of testsuite results</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="testsuite" minOccurs="0" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="testsuite">
+                <xs:attribute name="package" type="xs:token" use="required">
+                  <xs:annotation>
+                    <xs:documentation xml:lang="en">Derived from testsuite/@name in the non-aggregated documents</xs:documentation>
+                  </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="id" type="xs:int" use="required">
+                  <xs:annotation>
+                    <xs:documentation xml:lang="en">Starts at '0' for the first testsuite and is incremented by 1 for each following testsuite</xs:documentation>
+                  </xs:annotation>
+                </xs:attribute>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:complexType name="testsuite">
+    <xs:annotation>
+      <xs:documentation xml:lang="en">Contains the results of executing a testsuite</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="properties">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Properties (e.g., environment settings) set during test execution</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="property" minOccurs="0" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:attribute name="name" use="required">
+                  <xs:simpleType>
+                    <xs:restriction base="xs:token">
+                      <xs:minLength value="1"/>
+                    </xs:restriction>
+                  </xs:simpleType>
+                </xs:attribute>
+                <xs:attribute name="value" type="xs:string" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="testcase" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:choice minOccurs="0">
+            <xs:element name="skipped" minOccurs="0" maxOccurs="1">
+              <xs:annotation>
+                <xs:documentation xml:lang="en">Indicates that the test was skipped.</xs:documentation>
+              </xs:annotation>
+              <xs:complexType>
+                <xs:simpleContent>
+                  <xs:extension base="pre-string">
+                    <xs:attribute name="message" type="xs:string">
+                      <xs:annotation>
+                        <xs:documentation xml:lang="en">The message specifying why the test case was skipped</xs:documentation>
+                      </xs:annotation>
+                    </xs:attribute>
+                  </xs:extension>
+                </xs:simpleContent>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="error" minOccurs="0" maxOccurs="1">
+              <xs:annotation>
+                <xs:documentation xml:lang="en">Indicates that the test errored.  An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test. Contains as a text node relevant data for the error, e.g., a stack trace</xs:documentation>
+              </xs:annotation>
+              <xs:complexType>
+                <xs:simpleContent>
+                  <xs:extension base="pre-string">
+                    <xs:attribute name="message" type="xs:string">
+                      <xs:annotation>
+                        <xs:documentation xml:lang="en">The error message. e.g., if a java exception is thrown, the return value of getMessage()</xs:documentation>
+                      </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="type" type="xs:string" use="required">
+                      <xs:annotation>
+                        <xs:documentation xml:lang="en">The type of error that occured. e.g., if a java execption is thrown the full class name of the exception.</xs:documentation>
+                      </xs:annotation>
+                    </xs:attribute>
+                  </xs:extension>
+                </xs:simpleContent>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="failure">
+              <xs:annotation>
+                <xs:documentation xml:lang="en">Indicates that the test failed. A failure is a test which the code has explicitly failed by using the mechanisms for that purpose. e.g., via an assertEquals. Contains as a text node relevant data for the failure, e.g., a stack trace</xs:documentation>
+              </xs:annotation>
+              <xs:complexType>
+                <xs:simpleContent>
+                  <xs:extension base="pre-string">
+                    <xs:attribute name="message" type="xs:string">
+                      <xs:annotation>
+                        <xs:documentation xml:lang="en">The message specified in the assert</xs:documentation>
+                      </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="type" type="xs:string" use="required">
+                      <xs:annotation>
+                        <xs:documentation xml:lang="en">The type of the assert.</xs:documentation>
+                      </xs:annotation>
+                    </xs:attribute>
+                  </xs:extension>
+                </xs:simpleContent>
+              </xs:complexType>
+            </xs:element>
+          </xs:choice>
+          <xs:attribute name="name" type="xs:token" use="required">
+            <xs:annotation>
+              <xs:documentation xml:lang="en">Name of the test method</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="classname" type="xs:token" use="required">
+            <xs:annotation>
+              <xs:documentation xml:lang="en">Full class name for the class the test method is in.</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="time" type="xs:decimal" use="required">
+            <xs:annotation>
+              <xs:documentation xml:lang="en">Time taken (in seconds) to execute the test</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="system-out">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Data that was written to standard out while the test was executed</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="pre-string">
+            <xs:whiteSpace value="preserve"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="system-err">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Data that was written to standard error while the test was executed</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="pre-string">
+            <xs:whiteSpace value="preserve"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="name" use="required">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">Full class name of the test for non-aggregated testsuite documents. Class name without the package for aggregated testsuites documents</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:minLength value="1"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="timestamp" type="ISO8601_DATETIME_PATTERN" use="required">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">when the test was executed. Timezone may not be specified.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="hostname" use="required">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">Host on which the tests were executed. 'localhost' should be used if the hostname cannot be determined.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:minLength value="1"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="tests" type="xs:int" use="required">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">The total number of tests in the suite</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="failures" type="xs:int" use="required">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">The total number of tests in the suite that failed. A failure is a test which the code has explicitly failed by using the mechanisms for that purpose. e.g., via an assertEquals</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="errors" type="xs:int" use="required">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">The total number of tests in the suite that errored. An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="skipped" type="xs:int" use="optional">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">The total number of ignored or skipped tests in the suite.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="time" type="xs:decimal" use="required">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">Time taken (in seconds) to execute the tests in the suite</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:simpleType name="pre-string">
+    <xs:restriction base="xs:string">
+      <xs:whiteSpace value="preserve"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/src/jenkins-junit.xsd
+++ b/src/jenkins-junit.xsd
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Source: https://svn.jenkins-ci.org/trunk/hudson/dtkit/dtkit-format/dtkit-junit-model/src/main/resources/com/thalesgroup/dtkit/junit/model/xsd/junit-4.xsd
+ 
+ This file available under the terms of the MIT License as follows:
+ 
+ *******************************************************************************
+ * Copyright (c) 2010 Thales Corporate Services SAS                             *
+ *                                                                              *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy *
+ * of this software and associated documentation files (the "Software"), to deal*
+ * in the Software without restriction, including without limitation the rights *
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell    *
+ * copies of the Software, and to permit persons to whom the Software is        *
+ * furnished to do so, subject to the following conditions:                     *
+ *                                                                              *
+ * The above copyright notice and this permission notice shall be included in   *
+ * all copies or substantial portions of the Software.                          *
+ *                                                                              *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR   *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE  *
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER       *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,*
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN    *
+ * THE SOFTWARE.                                                                *
+ ********************************************************************************
+ -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xs:element name="failure">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+            <xs:attribute name="message" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="error">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+            <xs:attribute name="message" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="properties">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="property" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="property">
+        <xs:complexType>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="value" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="skipped" type="xs:string"/>
+    <xs:element name="system-err" type="xs:string"/>
+    <xs:element name="system-out" type="xs:string"/>
+
+    <xs:element name="testcase">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="skipped" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="error" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="failure" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-out" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-err" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="assertions" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="classname" type="xs:string" use="optional"/>
+            <xs:attribute name="status" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuite">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="properties" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="testcase" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-out" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="system-err" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="tests" type="xs:string" use="required"/>
+            <xs:attribute name="failures" type="xs:string" use="optional"/>
+            <xs:attribute name="errors" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="disabled" type="xs:string" use="optional"/>
+            <xs:attribute name="skipped" type="xs:string" use="optional"/>
+            <xs:attribute name="timestamp" type="xs:string" use="optional"/>
+            <xs:attribute name="hostname" type="xs:string" use="optional"/>
+            <xs:attribute name="id" type="xs:string" use="optional"/>
+            <xs:attribute name="package" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuites">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="testsuite" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="tests" type="xs:string" use="optional"/>
+            <xs:attribute name="failures" type="xs:string" use="optional"/>
+            <xs:attribute name="disabled" type="xs:string" use="optional"/>
+            <xs:attribute name="errors" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+
+</xs:schema>

--- a/src/testdrive.F90
+++ b/src/testdrive.F90
@@ -317,8 +317,6 @@ module testdrive
   !> Open JUnit.xml file for CLI output of test results.
   subroutine junitxml_open_file()
   
-    implicit none
-    
     open(newunit=unit_junitxml, file='JUnit.xml', form='formatted', access='sequential', status='replace')
     
     if (unit_junitxml /= -1) then
@@ -330,7 +328,7 @@ module testdrive
         & '>'
     else
       write(error_unit, '(a)') "# Error: Could not open JUnit.xml for writing! Program stops."
-      stop 1
+      error stop 1
     endif
     
   end subroutine junitxml_open_file
@@ -338,8 +336,6 @@ module testdrive
   !> Close JUnit.xml file.
   subroutine junitxml_close_file()
   
-    implicit none
-    
     write(unit_junitxml,'(a)') '</testsuites>'
     close(unit_junitxml)
     
@@ -348,8 +344,6 @@ module testdrive
   !> Write opening tag for testsuite with name to JUnit.xml.
   subroutine junitxml_write_testsuite_opening_tag(testsuite_name, id)
   
-    implicit none
-    
     character(len=*), intent(in) :: testsuite_name
     integer, intent(in) :: id
     
@@ -383,8 +377,6 @@ module testdrive
   !> Write closing tag for testsuite to JUnit.xml.
   subroutine junitxml_write_testsuite_closing_tag()
   
-    implicit none
-    
     write(unit_junitxml,'(a)') '  <system-out/>'
     write(unit_junitxml,'(a)') '  <system-err/>'
     write(unit_junitxml,'(a)') '  </testsuite>'
@@ -396,8 +388,6 @@ module testdrive
   !> Shortens output to a single line in xml file.
   subroutine junitxml_write_testcase_single_tag(testcase_name)
   
-    implicit none
-    
     character(len=*), intent(in) :: testcase_name
     
     write(unit_junitxml,'(a)') &
@@ -412,8 +402,6 @@ module testdrive
   !> Write opening tag for testcase with name to JUnit.xml. Needed, if a failure occurred.
   subroutine junitxml_write_testcase_opening_tag(testcase_name)
   
-    implicit none
-    
     character(len=*), intent(in) :: testcase_name
     
     write(unit_junitxml,'(a)') &
@@ -428,8 +416,6 @@ module testdrive
   !> Write closing tag for testcase to JUnit.xml.
   subroutine junitxml_write_testcase_closing_tag(stdout)
   
-    implicit none
-
     character(len=*), intent(in) :: stdout
 
     if (len_trim(stdout) > 0) then
@@ -445,8 +431,6 @@ module testdrive
   !> Write failure message to JUnit.xml.
   subroutine junitxml_write_testcase_failure(message)
   
-    implicit none
-    
     character(len=*), intent(in) :: message
     
     write(unit_junitxml,'(a)') &
@@ -543,7 +527,7 @@ module testdrive
 
     type(error_type), allocatable :: error
     character(len=:), allocatable :: message
-    character(len=20) :: res
+    character(len=:), allocatable :: res
     character(len=:), allocatable :: stdout
     integer :: s, e
 
@@ -580,7 +564,7 @@ module testdrive
         res = res
       case default
         write(unit, '(a)') "Error: Unknown test result '" // res // "' in test '" // test%name // "'!"
-        stop 2
+        error stop 2
     end select
 
     if (allocated(error)) then

--- a/src/testdrive.F90
+++ b/src/testdrive.F90
@@ -348,8 +348,8 @@ module testdrive
     integer, intent(in) :: id
     
     character(len=80) :: hostname
-    character (len=8)  cdate
-    character (len=10) ctime
+    character(len=8)  :: cdate
+    character(len=10) :: ctime
 
     
     call hostnm(hostname)

--- a/test/main.f90
+++ b/test/main.f90
@@ -15,7 +15,9 @@
 program tester
   use, intrinsic :: iso_fortran_env, only : error_unit
   use testdrive, only : run_testsuite, new_testsuite, testsuite_type, &
-    & select_suite, run_selected, get_argument
+    & select_suite, run_selected, get_argument, &
+    & junitxml_open_file, junitxml_close_file, &
+    & junitxml_write_testsuite_opening_tag, junitxml_write_testsuite_closing_tag
   use test_check, only : collect_check
   use test_select, only : collect_select
   implicit none
@@ -34,18 +36,24 @@ program tester
   call get_argument(1, suite_name)
   call get_argument(2, test_name)
 
+  call junitxml_open_file()
+
   if (allocated(suite_name)) then
     is = select_suite(testsuites, suite_name)
     if (is > 0 .and. is <= size(testsuites)) then
       if (allocated(test_name)) then
         write(error_unit, fmt) "Suite:", testsuites(is)%name
+        call junitxml_write_testsuite_opening_tag(testsuites(is)%name, is)
         call run_selected(testsuites(is)%collect, test_name, error_unit, stat)
+        call junitxml_write_testsuite_closing_tag()
         if (stat < 0) then
           error stop 1
         end if
       else
         write(error_unit, fmt) "Testing:", testsuites(is)%name
+        call junitxml_write_testsuite_opening_tag(testsuites(is)%name, is)
         call run_testsuite(testsuites(is)%collect, error_unit, stat)
+        call junitxml_write_testsuite_closing_tag()
       end if
     else
       write(error_unit, fmt) "Available testsuites"
@@ -57,7 +65,9 @@ program tester
   else
     do is = 1, size(testsuites)
       write(error_unit, fmt) "Testing:", testsuites(is)%name
+      call junitxml_write_testsuite_opening_tag(testsuites(is)%name, is)
       call run_testsuite(testsuites(is)%collect, error_unit, stat)
+      call junitxml_write_testsuite_closing_tag()
     end do
   end if
 
@@ -66,5 +76,6 @@ program tester
     error stop 1
   end if
 
+  call junitxml_close_file()
 
 end program tester


### PR DESCRIPTION
I have attached two changed source files (replacing src/testdrive.f90 and test/main.f90) as well as the resulting JUnit.xml file that is written along with the screen output. This xml is doing the job for us in an Azure DevOps pipeline based on the data that is also written on the screen.
The main.f90 uses 4 additional external subroutines from testdrive.f90. Two to open and close the Junit.xml and two to open and close the xml tag. The rest of the xml output is covered internally in testdrive.f90.
However, I assume that you would prefer to avoid these additional functions, but I choose a simple approach with minimal code changes, instead of a major rework of the module structure.

In addition, the JUnit.xml file references to an xml schema (JUnit.xsd from https://github.com/windyroad/JUnit-Schema). In theory the JUnit.xml should be conform to this schema, but it is not for several reasons:

There are missing (required) xml tag attributes, like number of all/failed/succeeded/skipped tests per testsuite that are as summarized data not available at the time, when the according opening xml tag is written.
There are missing xml tag attributes, like execution time, that are not stored in the code (as far as I could see).
There is no corresponding xml tag in the schema file for the additional stdout/stderr output per testcase. Therefore, I added according xml tags () per testcase that are - following the xsd - only allowed once per testsuite.
Fortunately, Azure DevOps does not care about the discrepancy, so we are fine with this setup (but it is not a generic solution).
I have also attached another xml schema file (jenkins-junit.xsd from https://github.com/junit-team/junit5 resp. https://junit.org/junit5/). To be honest I am not sure, what should be regarded as the standard for a JUnit.xml. In fact, I do not care much, since Azure DevOps test pipeline works fine. Others, however, may have a more specific opinion on the subject.

Let me know, if you want to discuss my changes or whether I can support you.
Thank you for considering my changes.