### PR TITLE
Remove gcc-6 on macos-latest and gcc-[78] on ubuntu-latest workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,24 +47,6 @@ jobs:
           compiler: gnu
           version: 10
 
-        - os: macos-latest
-          build: cmake
-          build-type: debug
-          compiler: gnu
-          version: 6
-
-        - os: ubuntu-latest
-          build: meson
-          build-type: debug
-          compiler: gnu
-          version: 7
-
-        - os: ubuntu-latest
-          build: cmake
-          build-type: debug
-          compiler: gnu
-          version: 8
-
         - os: ubuntu-latest
           build: meson
           build-type: debug


### PR DESCRIPTION
Some compiler versions are no longer available on `*-latest` images; this PR removes them.

I have not attempted to add any newer versions to the workflows to make this change minimal.