### PR TITLE
Only include tests in subproject if explicitly requested

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -77,4 +77,6 @@ if install
 endif
 
 # add the testsuite
-subdir('test')
+if get_option('testing').auto() ? not meson.is_subproject() : get_option('testing').enabled()
+  subdir('test')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -32,3 +32,10 @@ option(
   value: 'auto',
   description: 'Support quadruple precision',
 )
+
+option(
+  'testing',
+  type: 'feature',
+  value: 'auto',
+  description: 'Enable testing of test-drive library',
+)


### PR DESCRIPTION
Adds feature parity with the CMake option to disable running of test-drive's tests