### PR TITLE
fix lfortran compiler, fails 4 tests. 

### DIFF
--- a/test/main.f90
+++ b/test/main.f90
@@ -14,7 +14,7 @@
 !> Driver for unit testing
 program tester
   use, intrinsic :: iso_fortran_env, only : error_unit
-  use, intrinsic :: ieee_arithmetic
+  use, intrinsic :: ieee_arithmetic, only: ieee_quiet_nan
   use testdrive, only : run_testsuite, new_testsuite, testsuite_type, &
     & select_suite, run_selected, get_argument, junit_output, junit_header, &
     & init_color_output

--- a/test/main.f90
+++ b/test/main.f90
@@ -14,6 +14,7 @@
 !> Driver for unit testing
 program tester
   use, intrinsic :: iso_fortran_env, only : error_unit
+  use, intrinsic :: ieee_arithmetic
   use testdrive, only : run_testsuite, new_testsuite, testsuite_type, &
     & select_suite, run_selected, get_argument, junit_output, junit_header, &
     & init_color_output
@@ -29,6 +30,7 @@ program tester
   stat = 0
   call junit_header(junit, "testdrive")
 
+  allocate(testsuites(2))
   testsuites = [ &
     new_testsuite("check", collect_check), &
     new_testsuite("select", collect_select) &

--- a/test/test_check.F90
+++ b/test/test_check.F90
@@ -22,7 +22,7 @@
 #endif
 
 module test_check
-  use, intrinsic :: ieee_arithmetic, only : ieee_value, ieee_quiet_nan
+  use, intrinsic :: ieee_arithmetic, only : ieee_value, ieee_quiet_nan 
   use testdrive, only : new_unittest, unittest_type, error_type, check, skip_test, to_string
   implicit none
   private
@@ -67,6 +67,7 @@ contains
     !> Collection of tests
     type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
+    allocate(testsuite(95))
     testsuite = [ &
       new_unittest("success", test_success), &
       new_unittest("failure", test_failure, should_fail=.true.), &

--- a/test/test_select.F90
+++ b/test/test_select.F90
@@ -29,6 +29,7 @@ contains
 
     !> Collection of tests
     type(unittest_type), allocatable, intent(out) :: testsuite(:)
+    allocate(testsuite(6))
 
     testsuite = [ &
       new_unittest("always-pass", always_pass), &
@@ -68,6 +69,8 @@ contains
     !> Collection of tests
     type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
+    allocate(testsuite(2))
+
     testsuite = [ &
       new_unittest("always-pass", always_pass), &
       new_unittest("always-fail", always_fail, should_fail=.true.) &
@@ -81,6 +84,7 @@ contains
 
     !> Collection of tests
     type(unittest_type), allocatable, intent(out) :: testsuite(:)
+    allocate(testsuite(2))
 
     testsuite = [ &
       new_unittest("always-pass", always_pass, should_fail=.true.), &


### PR DESCRIPTION
test-drive was not compiling with lfortran (0.57) due to:

```
fpm test --compiler lfortran --profile debug --flag "--cpp"
test_select.F90                        done.
test_check.F90                         done.
main.f90                               done.
test-drive-test                        failed.
[100%] Compiling...
/home/jorge/install/miniconda3/envs/pic/bin/../lib/gcc/x86_64-conda-linux-gnu/15.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: build/lfortran_68E2630F1735BEB5/test-drive/test_main.f90.o: in function `__module_test_check_test_cdp_nan':
LFortran:(.text+0x1015d): undefined reference to `ieee_quiet_nan'
/home/jorge/install/miniconda3/envs/pic/bin/../lib/gcc/x86_64-conda-linux-gnu/15.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: build/lfortran_68E2630F1735BEB5/test-drive/test_main.f90.o: in function `__module_test_check_test_cdp_nan_message':
LFortran:(.text+0x10264): undefined reference to `ieee_quiet_nan'
/home/jorge/install/miniconda3/envs/pic/bin/../lib/gcc/x86_64-conda-linux-gnu/15.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: build/lfortran_68E2630F1735BEB5/test-drive/test_main.f90.o: in function `__module_test_check_test_csp_nan':
LFortran:(.text+0x10f3c): undefined reference to `ieee_quiet_nan'
/home/jorge/install/miniconda3/envs/pic/bin/../lib/gcc/x86_64-conda-linux-gnu/15.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: build/lfortran_68E2630F1735BEB5/test-drive/test_main.f90.o: in function `__module_test_check_test_csp_nan_message':
LFortran:(.text+0x11043): undefined reference to `ieee_quiet_nan'
/home/jorge/install/miniconda3/envs/pic/bin/../lib/gcc/x86_64-conda-linux-gnu/15.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: build/lfortran_68E2630F1735BEB5/test-drive/test_main.f90.o: in function `__module_test_check_test_rdp_nan':
LFortran:(.text+0x129a5): undefined reference to `ieee_quiet_nan'
/home/jorge/install/miniconda3/envs/pic/bin/../lib/gcc/x86_64-conda-linux-gnu/15.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: build/lfortran_68E2630F1735BEB5/test-drive/test_main.f90.o:LFortran:(.text+0x12a6c): more undefined references to `ieee_quiet_nan' follow
collect2: error: ld returned 1 exit status
```
A simple test requiring quiet_nan worked separately. That is why I had to add use the `use, intrinsic :: ieee_arithmetic, only: ieee_quiet_nan` in the main for tests. 

After that, you'd get runtime failures saying that testsuite(s) was not allocated. That was duct tape fixed by adding the allocate. I believe this are probably lfortran bugs. I am just opening this to showcase what caused the errors. 