### PR TITLE
Allow users to configure the module-dir install path

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -15,8 +15,14 @@ option(BUILD_SHARED_LIBS "Whether the libraries built should be shared" FALSE)
 option(TESTDRIVE_BUILD_TESTING "Enable testing for this project" ON)
 
 set(
-  module-dir
+  "${PROJECT_NAME}-module-dir"
   "${PROJECT_NAME}/${CMAKE_Fortran_COMPILER_ID}-${CMAKE_Fortran_COMPILER_VERSION}"
+  CACHE STRING
+  "Subdirectory to install generated module files to"
+)
+set(
+  module-dir
+  "${${PROJECT_NAME}-module-dir}"
 )
 set(module-dir "${module-dir}" PARENT_SCOPE)
 


### PR DESCRIPTION
Inspired from [toml-f](https://github.com/toml-f/toml-f/blob/ef0444cd80dbe573d0e69e31eb6609d2106032dd/config/CMakeLists.txt#L16-L26). It is a good design, all other projects should also adopt it. One flaw with this is that it does not account for if the path is an absolute path, and `CMAKE_INSTALL_INCLUDEDIR` is overloaded for both C and Fortran which would cause problems with mixed language projects.

This is necessary to comply with packaging guidelines of the distros.