### PR TITLE
Move make_output into omp critical to avoid race + crash with gfortran 14.x and parallel test runs

### DIFF
--- a/src/testdrive.F90
+++ b/src/testdrive.F90
@@ -555,8 +555,8 @@ contains
       if (allocated(error) .neqv. test%should_fail) stat = stat + 1
     end if
     call junit_push_test(junit, test, error, 0.0_sp)
-    call make_output(message, test, error)
     !$omp critical(testdrive_testsuite)
+    call make_output(message, test, error)
     write(unit, '(a)') message
     !$omp end critical(testdrive_testsuite)
     if (allocated(error)) then


### PR DESCRIPTION
Running tests in parallel (with openmp) apparently leads to a data race with gfortran 14.x; 13.x and 15.x are not affected and ifx also not. On macos this shows as a malloc(): unaligned tcache chunk detected and as SIGABRT on Linux.

I found this on accident while working on moist ([ubuntu (fpm, gnu14)](https://github.com/lukaswittmann/moist/actions/runs/28651136679/job/84969181061?pr=6#logs) and [macos (fpm, gnu14)](https://github.com/lukaswittmann/moist/actions/runs/28651136679/job/84969181005?pr=6#logs))

Relevant macos guard malloc (libgmalloc) (moist's radii testsuite on 8 threads):
```
* thread #3, stop reason = EXC_BAD_ACCESS (code=1, address=0x1785c8000)
  * frame #0: 0x0000000184677504 libsystem_platform.dylib`_platform_memmove + 420
    frame #1: 0x0000000100b2459c libgfortran.5.dylib`_gfortran_concat_string + 60
    frame #2: 0x000000010034cb0c tester`__testdrive_MOD_make_output at testdrive.F90:622:78
    frame #3: 0x000000010034d4ec tester`__testdrive_MOD_run_unittest at testdrive.F90:558:42
    frame #4: 0x000000010034e57c tester`__testdrive_MOD_run_testsuite._omp_fn.0 at testdrive.F90:485:57
```
while another thread is in same code path at the same instant:
```
    frame #7: 0x0000000100336cfc tester`__testdrive_MOD_concat_color_left at testdrive.F90:2880:36
    frame #8: 0x000000010034cba0 tester`__testdrive_MOD_make_output at testdrive.F90:622:78
    frame #9: 0x000000010034d4ec tester`__testdrive_MOD_run_unittest at testdrive.F90:558:42
```

<details><summary>Macos guard malloc (libgmalloc) full dump</summary>
<p>
```
(lldb) target create "build/arm64-apple-darwin20.0.0-gfortran_A5C3D4E8E2194DB3/test/tester"
Current executable set to '/Users/wittmann/Documents/projects/software-programs/moist/build/arm64-apple-darwin20.0.0-gfortran_A5C3D4E8E2194DB3/test/tester' (arm64).
(lldb) command source -s 0 '/tmp/lldb_full.txt'
Executing commands in '/tmp/lldb_full.txt'.
(lldb) settings set target.env-vars DYLD_INSERT_LIBRARIES=/usr/lib/libgmalloc.dylib
(lldb) settings set target.env-vars OMP_NUM_THREADS=6
(lldb) settings set target.env-vars MALLOC_FILL_SPACE=1
(lldb) run radii
GuardMalloc[tester-61532]: Allocations will be placed on 16 byte boundaries.
GuardMalloc[tester-61532]:  - Some buffer overruns may not be noticed.
GuardMalloc[tester-61532]:  - Applications using vector instructions (e.g., SSE) should work.
GuardMalloc[tester-61532]: version 064575.39.1
# Testing: radii
  Starting StaticRadiiCPCM ... (1/19)
  Starting RadiiConstructorVerbosity ... (3/19)
  Starting StaticRadiiConstructors ... (2/19)
  Starting StaticRadiiZeroGradient ... (4/19)
  Starting StaticRadiiNeedsUpdate ... (5/19)
  Starting DracoRadiiDummy ... (6/19)
       ... RadiiConstructorVerbosity [PASSED]
       ... StaticRadiiNeedsUpdate [PASSED]
  Starting CustomRadiiAtomsWorks ... (7/19)
  Starting CustomRadiiElementsWorks ... (8/19)
PASSED]
Process 61532 launched: '/Users/wittmann/Documents/projects/software-programs/moist/build/arm64-apple-darwin20.0.0-gfortran_A5C3D4E8E2194DB3/test/tester' (arm64)
Process 61532 stopped
* thread #3, stop reason = EXC_BAD_ACCESS (code=1, address=0x1785c8000)
    frame #0: 0x0000000184677504 libsystem_platform.dylib`_platform_memmove + 420
libsystem_platform.dylib`_platform_memmove:
->  0x184677504 <+420>: ldr    x6, [x1], #0x8
    0x184677508 <+424>: str    x6, [x3], #0x8
    0x18467750c <+428>: subs   x2, x2, #0x8
    0x184677510 <+432>: b.hs   0x184677504               ; <+420>
Target 0: (tester) stopped.
(lldb) bt all
  thread #1, queue = 'com.apple.main-thread'
    frame #0: 0x00000001008fd8b4 libomp.dylib`__kmp_eq_4
    frame #1: 0x00000001008fd9d0 libomp.dylib`__kmp_wait_4 + 224
    frame #2: 0x0000000100903f74 libomp.dylib`int __kmp_acquire_queuing_lock_timed_template<false>(kmp_queuing_lock*, int) + 464
    frame #3: 0x0000000100908684 libomp.dylib`__kmp_acquire_queuing_lock(kmp_user_lock*, int) + 12
    frame #4: 0x00000001008ba388 libomp.dylib`__kmpc_critical_with_hint + 1040
    frame #5: 0x000000010034d500 tester`__testdrive_MOD_run_unittest at testdrive.F90:559:39
    frame #6: 0x000000010034e57c tester`__testdrive_MOD_run_testsuite._omp_fn.0 at testdrive.F90:485:57
    frame #7: 0x000000010091dc98 libomp.dylib`GOMP_parallel + 256
    frame #8: 0x000000010034dab4 tester`__testdrive_MOD_run_testsuite at testdrive.F90:476:24
    frame #9: 0x0000000100003ba4 tester`MAIN__ at main.F90:86:72
    frame #10: 0x0000000100003f34 tester`main at main.F90:7:35
    frame #11: 0x00000001842afe00 dyld`start + 6992
  thread #2
    frame #0: 0x0000000184629aa8 libsystem_kernel.dylib`_kernelrpc_mach_vm_deallocate_trap + 8
    frame #1: 0x000000018462b804 libsystem_kernel.dylib`mach_vm_deallocate + 88
    frame #2: 0x0000000100652368 libgmalloc.dylib`GuardMalloc_freeInternal + 156
    frame #3: 0x0000000100336ba4 tester`__testdrive_MOD_concat_color_right at testdrive.F90:2892:36
    frame #4: 0x000000010034ddfc tester`__testdrive_MOD_run_testsuite._omp_fn.0 at testdrive.F90:481:39
    frame #5: 0x000000010091773c libomp.dylib`__kmp_GOMP_microtask_wrapper(int*, int*, void (*)(void*), void*) + 72
    frame #6: 0x000000010093181c libomp.dylib`__kmp_invoke_microtask + 156
    frame #7: 0x00000001008cbe3c libomp.dylib`__kmp_invoke_task_func + 336
    frame #8: 0x00000001008caaf8 libomp.dylib`__kmp_launch_thread + 420
    frame #9: 0x0000000100912c38 libomp.dylib`__kmp_launch_worker(void*) + 280
    frame #10: 0x000000018466dc58 libsystem_pthread.dylib`_pthread_start + 136
* thread #3, stop reason = EXC_BAD_ACCESS (code=1, address=0x1785c8000)
  * frame #0: 0x0000000184677504 libsystem_platform.dylib`_platform_memmove + 420
    frame #1: 0x0000000100b2459c libgfortran.5.dylib`_gfortran_concat_string + 60
    frame #2: 0x000000010034cb0c tester`__testdrive_MOD_make_output at testdrive.F90:622:78
    frame #3: 0x000000010034d4ec tester`__testdrive_MOD_run_unittest at testdrive.F90:558:42
    frame #4: 0x000000010034e57c tester`__testdrive_MOD_run_testsuite._omp_fn.0 at testdrive.F90:485:57
    frame #5: 0x000000010091773c libomp.dylib`__kmp_GOMP_microtask_wrapper(int*, int*, void (*)(void*), void*) + 72
    frame #6: 0x000000010093181c libomp.dylib`__kmp_invoke_microtask + 156
    frame #7: 0x00000001008cbe3c libomp.dylib`__kmp_invoke_task_func + 336
    frame #8: 0x00000001008caaf8 libomp.dylib`__kmp_launch_thread + 420
    frame #9: 0x0000000100912c38 libomp.dylib`__kmp_launch_worker(void*) + 280
    frame #10: 0x000000018466dc58 libsystem_pthread.dylib`_pthread_start + 136
  thread #4
    frame #0: 0x0000000184637c98 libsystem_kernel.dylib`__ulock_wait2 + 8
    frame #1: 0x00000001846753c0 libsystem_platform.dylib`_os_unfair_lock_lock_slow + 172
    frame #2: 0x000000010065237c libgmalloc.dylib`GuardMalloc_freeInternal + 176
    frame #3: 0x000000010034c818 tester`__testdrive_MOD_make_output at testdrive.F90:622:78
    frame #4: 0x000000010034d4ec tester`__testdrive_MOD_run_unittest at testdrive.F90:558:42
    frame #5: 0x000000010034e57c tester`__testdrive_MOD_run_testsuite._omp_fn.0 at testdrive.F90:485:57
    frame #6: 0x000000010091773c libomp.dylib`__kmp_GOMP_microtask_wrapper(int*, int*, void (*)(void*), void*) + 72
    frame #7: 0x000000010093181c libomp.dylib`__kmp_invoke_microtask + 156
    frame #8: 0x00000001008cbe3c libomp.dylib`__kmp_invoke_task_func + 336
    frame #9: 0x00000001008caaf8 libomp.dylib`__kmp_launch_thread + 420
    frame #10: 0x0000000100912c38 libomp.dylib`__kmp_launch_worker(void*) + 280
    frame #11: 0x000000018466dc58 libsystem_pthread.dylib`_pthread_start + 136
  thread #5
    frame #0: 0x00000001008fd8b4 libomp.dylib`__kmp_eq_4
    frame #1: 0x00000001008fd9d0 libomp.dylib`__kmp_wait_4 + 224
    frame #2: 0x0000000100903f74 libomp.dylib`int __kmp_acquire_queuing_lock_timed_template<false>(kmp_queuing_lock*, int) + 464
    frame #3: 0x0000000100908684 libomp.dylib`__kmp_acquire_queuing_lock(kmp_user_lock*, int) + 12
    frame #4: 0x00000001008ba388 libomp.dylib`__kmpc_critical_with_hint + 1040
    frame #5: 0x000000010034d500 tester`__testdrive_MOD_run_unittest at testdrive.F90:559:39
    frame #6: 0x000000010034e57c tester`__testdrive_MOD_run_testsuite._omp_fn.0 at testdrive.F90:485:57
    frame #7: 0x000000010091773c libomp.dylib`__kmp_GOMP_microtask_wrapper(int*, int*, void (*)(void*), void*) + 72
    frame #8: 0x000000010093181c libomp.dylib`__kmp_invoke_microtask + 156
    frame #9: 0x00000001008cbe3c libomp.dylib`__kmp_invoke_task_func + 336
    frame #10: 0x00000001008caaf8 libomp.dylib`__kmp_launch_thread + 420
    frame #11: 0x0000000100912c38 libomp.dylib`__kmp_launch_worker(void*) + 280
    frame #12: 0x000000018466dc58 libsystem_pthread.dylib`_pthread_start + 136
  thread #6
    frame #0: 0x0000000184629a90 libsystem_kernel.dylib`_kernelrpc_mach_vm_allocate_trap + 8
    frame #1: 0x000000018462c030 libsystem_kernel.dylib`mach_vm_allocate + 44
    frame #2: 0x000000018462bfec libsystem_kernel.dylib`vm_allocate + 40
    frame #3: 0x0000000100652bac libgmalloc.dylib`GuardMalloc_mallocInternal + 640
    frame #4: 0x000000018449a178 libsystem_malloc.dylib`_malloc_zone_malloc_instrumented_or_legacy + 152
    frame #5: 0x000000018447e678 libsystem_malloc.dylib`_malloc_type_malloc_outlined + 96
    frame #6: 0x000000018447e65c libsystem_malloc.dylib`_malloc_type_malloc_outlined + 68
    frame #7: 0x0000000100336cfc tester`__testdrive_MOD_concat_color_left at testdrive.F90:2880:36
    frame #8: 0x000000010034cba0 tester`__testdrive_MOD_make_output at testdrive.F90:622:78
    frame #9: 0x000000010034d4ec tester`__testdrive_MOD_run_unittest at testdrive.F90:558:42
    frame #10: 0x000000010034e57c tester`__testdrive_MOD_run_testsuite._omp_fn.0 at testdrive.F90:485:57
    frame #11: 0x000000010091773c libomp.dylib`__kmp_GOMP_microtask_wrapper(int*, int*, void (*)(void*), void*) + 72
    frame #12: 0x000000010093181c libomp.dylib`__kmp_invoke_microtask + 156
    frame #13: 0x00000001008cbe3c libomp.dylib`__kmp_invoke_task_func + 336
    frame #14: 0x00000001008caaf8 libomp.dylib`__kmp_launch_thread + 420
    frame #15: 0x0000000100912c38 libomp.dylib`__kmp_launch_worker(void*) + 280
    frame #16: 0x000000018466dc58 libsystem_pthread.dylib`_pthread_start + 136
(lldb) quit
```
</p>
</details> 

Moving the `make_output(...)` call into the write omp critical region fixes these issues (this PR). 

Edit: I do not understand why exaclty this is an issue (esp. why just with gnu14.x); it could also be that I am missing something.


